### PR TITLE
Correction lors de l'appel de la fonction

### DIFF
--- a/chapitre_6/js/mot.js
+++ b/chapitre_6/js/mot.js
@@ -91,5 +91,5 @@ if (motInverse.toLowerCase() === motSaisi.toLowerCase()) {
     console.log("Ce n'est pas un palindrome");
 }
 
-var motLeetSpeak = convertirEnLeetSpeek(motSaisi);
+var motLeetSpeak = convertirEnLeetSpeak(motSaisi);
 console.log("Il s'écrit en leet speak " + motLeetSpeak);


### PR DESCRIPTION
Ligne 94, changement "convertirEnLeetSpeek(motSaisi)" en "convertirEnLeetSpeak(motSaisi)"
Faute de frappe lors de l'appel de la fonction corrigée